### PR TITLE
Prevent from inserting duplicate balances

### DIFF
--- a/src/routes/app/wallets/index.tsx
+++ b/src/routes/app/wallets/index.tsx
@@ -61,7 +61,7 @@ import {
   getObservedWallets,
   ObservedWalletsList,
 } from "~/components/ObservedWalletsList/ObservedWalletsList";
-import {EndpointWeightsResponseAdapter, EvmChain} from "@moralisweb3/common-evm-utils";
+import { EvmChain } from "@moralisweb3/common-evm-utils";
 import { convertWeiToQuantity } from "~/utils/formatBalances/formatTokenBalance";
 
 export const useAddWallet = routeAction$(
@@ -149,15 +149,17 @@ export const useGetBalanceHistory = routeAction$(async (data, requestEvent) => {
 
   const responses = [];
   for (const tx of walletTransactions) {
-    if(!balanceHistory.some(entry => entry.blockNumber === tx.block_number)) {
-    balanceHistory.push({
-      blockNumber: tx.block_number,
-      timestamp: tx.block_timestamp,
-    });
+    if (
+      !balanceHistory.some((entry) => entry.blockNumber === tx.block_number)
+    ) {
+      balanceHistory.push({
+        blockNumber: tx.block_number,
+        timestamp: tx.block_timestamp,
+      });
 
-    responses.push(
-      await getWalletBalance(tx.block_number, data.address as string),
-    );
+      responses.push(
+        await getWalletBalance(tx.block_number, data.address as string),
+      );
     }
   }
 
@@ -176,7 +178,7 @@ export const useGetBalanceHistory = routeAction$(async (data, requestEvent) => {
 
   await db.query(`
   DEFINE INDEX walletBalanceBlock ON TABLE wallet_balance COLUMNS blockNumber, walletAddress UNIQUE
-  `)
+  `);
 
   for (let i = 0; i < responses.length; i++) {
     const currentBalance: { [key: string]: string } = {};
@@ -206,9 +208,8 @@ export const useGetBalanceHistory = routeAction$(async (data, requestEvent) => {
     try {
       await db.create("wallet_balance", dbObject);
     } catch (error) {
-      console.warn('duplicate entry, operation ignored. ')
+      console.warn("duplicate entry, operation ignored. ");
     }
-
   }
 });
 


### PR DESCRIPTION
Since getWalletTokenTransfers is also pulling approvals I added the filter to prevent from duplicate blocks to be added (per wallet) which prevents from duplicate entries in the database.

I also added composite constraint to the DB itself to throw a warn in case duplicate combination of walletAddress and blockNumber is to be inserted.