### PR TITLE
Run e2e only on `test/*` branches for testing purposes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,9 +2,11 @@ name: E2E
 
 on:
   push:
-    branches: ["master", "dev"]
+    # branches: ["master", "dev"]
+    branches: ["test/*"]
   pull_request:
-    branches: ["master", "dev"]
+    # branches: ["master", "dev"]
+    branches: ["test/*"]
 
 env:
   # Workflow context variables


### PR DESCRIPTION
Until we'll figure out issues with Synpress run in CI, let's keep `e2e` workflow only for `test/*` branches to not lock our regular development.