### PR TITLE
Disable convert button 

### DIFF
--- a/src/components/Forms/AddWalletFormFields.tsx
+++ b/src/components/Forms/AddWalletFormFields.tsx
@@ -117,7 +117,7 @@ export default component$<AddWalletFormFieldsProps>(
               <Input
                 type="text"
                 name="address"
-                customClass={`${!isValidAddress(addWalletFormStore.address) ? "border-red-700" : ""} mt-4 w-full`}
+                customClass={`${!isValidAddress(addWalletFormStore.address) || !isCheckSum(addWalletFormStore.address) ? "border-red-700" : ""} mt-4 w-full`}
                 value={addWalletFormStore.address}
                 placeholder="Enter wallet address..."
                 onInput={$((e) => {
@@ -139,7 +139,7 @@ export default component$<AddWalletFormFieldsProps>(
                 disabled={
                   addWalletFormStore.address.length === 0 ||
                   !isValidAddress(addWalletFormStore.address) ||
-                  !isCheckSum(addWalletFormStore.address)
+                  isCheckSum(addWalletFormStore.address)
                 }
               />
             </div>

--- a/src/routes/app/wallets/index.tsx
+++ b/src/routes/app/wallets/index.tsx
@@ -458,7 +458,7 @@ export default component$(() => {
                   class="w-full border-0 bg-customBlue text-white duration-300 ease-in-out hover:scale-105 disabled:scale-100 disabled:cursor-default disabled:border disabled:border-white disabled:border-opacity-10 disabled:bg-white disabled:bg-opacity-10 disabled:text-opacity-20"
                   onClick$={handleAddWallet}
                   type="button"
-                  disabled={isExecutableDisabled(addWalletFormStore)}
+                  disabled={isNotExecutableDisabled(addWalletFormStore)}
                   text="Add Wallet"
                 />
               ) : stepsCounter.value === 3 ? (

--- a/src/utils/validators/addWallet.ts
+++ b/src/utils/validators/addWallet.ts
@@ -129,4 +129,5 @@ export const isNotExecutableDisabled = (
   !isValidAddress(addWalletFormStore.address) ||
   !addWalletFormStore.isNameUnique ||
   addWalletFormStore.isNameUniqueLoading ||
-  !addWalletFormStore.isAddressUnique;
+  !addWalletFormStore.isAddressUnique ||
+  !isCheckSum(addWalletFormStore.address);


### PR DESCRIPTION
- updated convert button to be disabled if address is checksum
- updated add wallet button to be disabled when the address is not checksum

did not change the input field outline since nothing is mentioned about that in figma design

This PR Closes Issue #137