### PR TITLE
Fix for batch transfers with no subportfolio/subportfolio with no exe wallet

### DIFF
--- a/src/components/Forms/portfolioTransfters/CoinsToTransfer.tsx
+++ b/src/components/Forms/portfolioTransfters/CoinsToTransfer.tsx
@@ -3,6 +3,7 @@ import { FormBadge } from "~/components/FormBadge/FormBadge";
 
 import IconArrowDown from "/public/assets/icons/arrow-down.svg?jsx";
 import { type BatchTransferFormStore } from "~/routes/app/portfolio/interface";
+import { hasExecutableWallet } from "~/utils/validators/availableStructure";
 
 export interface CoinsToTransferProps {
   batchTransferFormStore: BatchTransferFormStore;
@@ -17,59 +18,61 @@ export default component$<CoinsToTransferProps>(
           (structure: any, index: number) => {
             return (
               <>
-                <div
-                  class="scrollbar mb-4 flex max-h-[250px] flex-col overflow-auto"
-                  key={`${structure.name}${index}`}
-                >
-                  <div class="flex gap-2">
-                    <IconArrowDown />
-                    <p class="text-sm">{structure.structure.name}</p>
-                  </div>
-                  <div class="mr-2 flex flex-col py-2">
-                    {structure.structureBalance.map(
-                      (balance: any, index: number) => {
-                        const currentStructure =
-                          batchTransferFormStore.coinsToTransfer.find(
-                            (struct) =>
-                              struct.name === structure.structure.name,
+                {hasExecutableWallet(structure) ? (
+                  <div
+                    class="scrollbar mb-4 flex max-h-[250px] flex-col overflow-auto"
+                    key={`${structure.name}${index}`}
+                  >
+                    <div class="flex gap-2">
+                      <IconArrowDown />
+                      <p class="text-sm">{structure.structure.name}</p>
+                    </div>
+                    <div class="mr-2 flex flex-col py-2">
+                      {structure.structureBalance.map(
+                        (balance: any, index: number) => {
+                          const currentStructure =
+                            batchTransferFormStore.coinsToTransfer.find(
+                              (struct) =>
+                                struct.name === structure.structure.name,
+                            );
+
+                          const currentCoin = currentStructure!.coins.find(
+                            (item) =>
+                              item.wallet === balance.wallet.name &&
+                              item.symbol === balance.balance.symbol,
                           );
 
-                        const currentCoin = currentStructure!.coins.find(
-                          (item) =>
-                            item.wallet === balance.wallet.name &&
-                            item.symbol === balance.balance.symbol,
-                        );
-
-                        return balance.wallet.isExecutable ? (
-                          <FormBadge
-                            key={index}
-                            text={balance.balance.symbol}
-                            class="mb-2"
-                            customClass="h-[56px]"
-                            labelClass="start-4"
-                            description={balance.wallet.name}
-                            image={`/assets/icons/tokens/${balance.balance.symbol.toLowerCase()}.svg`}
-                            for={`${structure.structure.name}${balance.wallet.name}${balance.balance.symbol}`}
-                            input={
-                              <input
-                                id={`${structure.structure.name}${balance.wallet.name}${balance.balance.symbol}`}
-                                name={`${structure.structure.name}${balance.wallet.name}${balance.balance.symbol}`}
-                                type="checkbox"
-                                checked={currentCoin!.isChecked}
-                                // value={`${structure.structure.name}${balance.balance.symbol}`}
-                                class="border-gradient custom-border-1 custom-bg-white checked checked:after:border-bg absolute end-4 z-10  h-6 w-6 appearance-none rounded checked:after:absolute checked:after:left-1/2 checked:after:top-1/2 checked:after:h-2.5 checked:after:w-1.5 checked:after:-translate-x-1/2 checked:after:-translate-y-1/2 checked:after:rotate-45 checked:after:border-solid hover:cursor-pointer focus:after:absolute focus:after:z-[1]"
-                                onClick$={() => {
-                                  currentCoin!.isChecked =
-                                    !currentCoin?.isChecked;
-                                }}
-                              />
-                            }
-                          />
-                        ) : null;
-                      },
-                    )}
+                          return balance.wallet.isExecutable ? (
+                            <FormBadge
+                              key={index}
+                              text={balance.balance.symbol}
+                              class="mb-2"
+                              customClass="h-[56px]"
+                              labelClass="start-4"
+                              description={balance.wallet.name}
+                              image={`/assets/icons/tokens/${balance.balance.symbol.toLowerCase()}.svg`}
+                              for={`${structure.structure.name}${balance.wallet.name}${balance.balance.symbol}`}
+                              input={
+                                <input
+                                  id={`${structure.structure.name}${balance.wallet.name}${balance.balance.symbol}`}
+                                  name={`${structure.structure.name}${balance.wallet.name}${balance.balance.symbol}`}
+                                  type="checkbox"
+                                  checked={currentCoin!.isChecked}
+                                  // value={`${structure.structure.name}${balance.balance.symbol}`}
+                                  class="border-gradient custom-border-1 custom-bg-white checked checked:after:border-bg absolute end-4 z-10  h-6 w-6 appearance-none rounded checked:after:absolute checked:after:left-1/2 checked:after:top-1/2 checked:after:h-2.5 checked:after:w-1.5 checked:after:-translate-x-1/2 checked:after:-translate-y-1/2 checked:after:rotate-45 checked:after:border-solid hover:cursor-pointer focus:after:absolute focus:after:z-[1]"
+                                  onClick$={() => {
+                                    currentCoin!.isChecked =
+                                      !currentCoin?.isChecked;
+                                  }}
+                                />
+                              }
+                            />
+                          ) : null;
+                        },
+                      )}
+                    </div>
                   </div>
-                </div>
+                ) : null}
               </>
             );
           },

--- a/src/interface/structure/Structure.ts
+++ b/src/interface/structure/Structure.ts
@@ -5,6 +5,6 @@ export type Structure = {
   structureBalance: StructureBalance[];
 };
 export type StructureBalance = {
-  wallet: { id: string; name: string; chainId: number };
+  wallet: { id: string; name: string; chainId: number; isExecutable: boolean };
   balance: TokenWithBalance;
 };

--- a/src/routes/app/portfolio/index.tsx
+++ b/src/routes/app/portfolio/index.tsx
@@ -63,7 +63,7 @@ import { FormBadge } from "~/components/FormBadge/FormBadge";
 import { Spinner } from "~/components/Spinner/Spinner";
 
 import { type ObservedBalanceDetails } from "~/interface/walletsTokensBalances/walletsTokensBalances";
-import {hasExecutableWallet} from "~/utils/validators/availableStructure";
+import { hasExecutableWallet } from "~/utils/validators/availableStructure";
 
 export default component$(() => {
   const wagmiConfig = useContext(WagmiConfigContext);
@@ -271,7 +271,9 @@ export default component$(() => {
                 variant="transparent"
                 text="Transfer"
                 size="small"
-                disabled={!hasExecutableWallet(availableStructures.value.structures)}
+                disabled={
+                  !hasExecutableWallet(availableStructures.value.structures)
+                }
                 onClick$={async () => {
                   for (const structure of availableStructures.value
                     .structures) {
@@ -387,6 +389,7 @@ export default component$(() => {
           <div class="mb-4 flex flex-col overflow-y-scroll">
             {stepsCounter.value === 1 ? (
               <CoinsToTransfer
+                // add filter to exclude structures with no exe wallet
                 availableStructures={availableStructures}
                 batchTransferFormStore={batchTransferFormStore}
               />

--- a/src/routes/app/portfolio/index.tsx
+++ b/src/routes/app/portfolio/index.tsx
@@ -63,6 +63,7 @@ import { FormBadge } from "~/components/FormBadge/FormBadge";
 import { Spinner } from "~/components/Spinner/Spinner";
 
 import { type ObservedBalanceDetails } from "~/interface/walletsTokensBalances/walletsTokensBalances";
+import {hasExecutableWallet} from "~/utils/validators/availableStructure";
 
 export default component$(() => {
   const wagmiConfig = useContext(WagmiConfigContext);
@@ -270,6 +271,7 @@ export default component$(() => {
                 variant="transparent"
                 text="Transfer"
                 size="small"
+                disabled={!hasExecutableWallet(availableStructures.value.structures)}
                 onClick$={async () => {
                   for (const structure of availableStructures.value
                     .structures) {

--- a/src/utils/validators/availableStructure.ts
+++ b/src/utils/validators/availableStructure.ts
@@ -1,7 +1,20 @@
-import type {Structure} from "~/interface/structure/Structure";
+import type {
+  Structure,
+  StructureBalance,
+} from "~/interface/structure/Structure";
 
-export const hasExecutableWallet = (structures: Structure[]) => {
-  return structures.some((structure: Structure) =>
-    structure.structureBalance.some((item: any) => item.wallet.isExecutable)
-  );
+export const hasExecutableWallet = (
+  structures: Structure[] | Structure,
+): boolean => {
+  if (Array.isArray(structures)) {
+    return structures.some((structure: Structure) =>
+      structure.structureBalance.some(
+        (item: StructureBalance) => item.wallet.isExecutable,
+      ),
+    );
+  } else {
+    return structures.structureBalance.some(
+      (item: StructureBalance) => item.wallet.isExecutable,
+    );
+  }
 };

--- a/src/utils/validators/availableStructure.ts
+++ b/src/utils/validators/availableStructure.ts
@@ -1,0 +1,7 @@
+import type {Structure} from "~/interface/structure/Structure";
+
+export const hasExecutableWallet = (structures: Structure[]) => {
+  return structures.some((structure: Structure) =>
+    structure.structureBalance.some((item: any) => item.wallet.isExecutable)
+  );
+};


### PR DESCRIPTION
- created a filter that looks if in created structures is token from executable wallet. 
- If is, then transfer button is enabled. Disabled otherwise.

Closes #134 