### PR TITLE
debugging loading balances for wallet

### DIFF
--- a/src/components/Tokens/TokenRowWallets.tsx
+++ b/src/components/Tokens/TokenRowWallets.tsx
@@ -11,19 +11,19 @@ import { server$ } from "@builder.io/qwik-city";
 import { useImageProvider, type ImageTransformerProps } from "qwik-image";
 import { Readable } from "stream";
 import { connectToDB } from "~/database/db";
+import { type actionType } from "~/routes/app/portfolio/interface";
 import { type TransferredCoinInterface } from "~/routes/app/wallets/interface";
 import { convertWeiToQuantity } from "~/utils/formatBalances/formatTokenBalance";
 import ParagraphAnnotation from "../Molecules/ParagraphAnnotation/ParagraphAnnotation";
 import { killLiveQuery } from "../ObservedWalletsList/ObservedWalletsList";
 import {
-  type LatestTokenBalance,
-  type LiveQueryResult,
   createLiveQuery,
   fetchLatestTokenBalance,
   fetchLatestTokenPrice,
+  type LatestTokenBalance,
+  type LiveQueryResult,
 } from "./tokenRowWalletsTypes";
 import IconGraph from "/public/assets/icons/graph.svg?jsx";
-import { type actionType } from "~/routes/app/portfolio/interface";
 
 type TokenRowWalletsProps = {
   walletId?: string;
@@ -47,7 +47,7 @@ export const tokenRowWalletsInfoStream = server$(async function* (
   const db = await connectToDB(this.env);
   const resultsStream = new Readable({
     objectMode: true,
-    read() { },
+    read() {},
   });
 
   const walletBalanceLiveQuery = `
@@ -213,8 +213,6 @@ export const TokenRowWallets = component$<TokenRowWalletsProps>(
         );
       }
 
-
-
       const latestTokenPriceQueryUuid: LiveQueryResult = (await data.next())
         .value;
       latestTokenPrice.value = (await data.next()).value["price"];
@@ -224,9 +222,10 @@ export const TokenRowWallets = component$<TokenRowWalletsProps>(
       for await (const value of data) {
         if (value.action === "CREATE") {
           if (value.type === "BALANCE") {
-            // console.log("create", value.result)
             recentTime = value.result["timestamp"];
-            if (new Date(recentTime).getTime() >= new Date(previousTime).getTime()) {
+            if (
+              new Date(recentTime).getTime() >= new Date(previousTime).getTime()
+            ) {
               currentBalanceOfToken.value = convertWeiToQuantity(
                 value.result["walletValue"],
                 parseInt(decimals),
@@ -275,7 +274,7 @@ export const TokenRowWallets = component$<TokenRowWalletsProps>(
           </div>
           <div class="text-right">
             {/* 
-            leave it till it will be necessary
+            leave it till it will be needed
             <Button
               variant="onlyIcon"
               leftIcon={<IconMenuDots class="w-4 h-4 fill-white/>}
@@ -283,6 +282,44 @@ export const TokenRowWallets = component$<TokenRowWalletsProps>(
           </div>
         </div>
       </>
-    ) : null;
+    ) : (
+      <>
+        <div class="custom-border-b-1 grid  grid-cols-[25%_18%_18%_18%_18%_18%] items-center gap-2 py-2 text-sm">
+          <ParagraphAnnotation
+            paragraphText={name}
+            annotationText={symbol}
+            variant="annotationNear"
+            hasIconBox={true}
+            iconBoxSize="small"
+            iconBoxTokenPath={imagePath}
+          />
+          <div
+            key={`${currentBalanceOfToken.value}:${symbol}`}
+            class="animate-fadeIn overflow-auto"
+          >
+            Loading...
+          </div>
+          <div
+            key={`${latestBalanceUSD.value}:${symbol}`}
+            class="animate-fadeIn overflow-auto"
+          >
+            $0.00
+          </div>
+          <div class="">{allowance}</div>
+          <div class="flex h-full items-center gap-4">
+            <span class="text-customGreen">3,6%</span>
+            <IconGraph />
+          </div>
+          <div class="text-right">
+            {/* 
+        leave it till it will be needed
+        <Button
+          variant="onlyIcon"
+          leftIcon={<IconMenuDots class="w-4 h-4 fill-white/>}
+        /> */}
+          </div>
+        </div>
+      </>
+    );
   },
 );

--- a/src/components/Tokens/TokenRowWallets.tsx
+++ b/src/components/Tokens/TokenRowWallets.tsx
@@ -47,7 +47,7 @@ export const tokenRowWalletsInfoStream = server$(async function* (
   const db = await connectToDB(this.env);
   const resultsStream = new Readable({
     objectMode: true,
-    read() {},
+    read() { },
   });
 
   const walletBalanceLiveQuery = `
@@ -213,17 +213,26 @@ export const TokenRowWallets = component$<TokenRowWalletsProps>(
         );
       }
 
+
+
       const latestTokenPriceQueryUuid: LiveQueryResult = (await data.next())
         .value;
       latestTokenPrice.value = (await data.next()).value["price"];
 
+      let previousTime = "1970-01-01T00:00:00Z";
+      let recentTime;
       for await (const value of data) {
         if (value.action === "CREATE") {
           if (value.type === "BALANCE") {
-            currentBalanceOfToken.value = convertWeiToQuantity(
-              value.result["walletValue"],
-              parseInt(decimals),
-            );
+            // console.log("create", value.result)
+            recentTime = value.result["timestamp"];
+            if (new Date(recentTime).getTime() >= new Date(previousTime).getTime()) {
+              currentBalanceOfToken.value = convertWeiToQuantity(
+                value.result["walletValue"],
+                parseInt(decimals),
+              );
+              previousTime = recentTime;
+            }
           } else {
             latestTokenPrice.value = value.result["price"];
           }

--- a/src/components/Tokens/TokenRowWallets.tsx
+++ b/src/components/Tokens/TokenRowWallets.tsx
@@ -217,19 +217,21 @@ export const TokenRowWallets = component$<TokenRowWalletsProps>(
         .value;
       latestTokenPrice.value = (await data.next()).value["price"];
 
-      let previousTime = new Date("1970-01-01T00:00:00Z").getTime();
+      let timeOfPreviousBalanceChange = new Date(
+        "1970-01-01T00:00:00Z",
+      ).getTime();
 
       for await (const { action, type, result } of data) {
         const { timestamp, walletValue, price } = result;
         if (action === "CREATE") {
           if (type === "BALANCE") {
-            let recentTime = timestamp;
-            if (new Date(recentTime).getTime() >= previousTime) {
+            const timeOfLatestBalanceChange = new Date(timestamp).getTime();
+            if (timeOfLatestBalanceChange >= timeOfPreviousBalanceChange) {
               currentBalanceOfToken.value = convertWeiToQuantity(
                 walletValue,
                 parseInt(decimals),
               );
-              previousTime = recentTime;
+              timeOfPreviousBalanceChange = timeOfLatestBalanceChange;
             }
           } else {
             latestTokenPrice.value = price;

--- a/src/components/Tokens/TokenRowWallets.tsx
+++ b/src/components/Tokens/TokenRowWallets.tsx
@@ -217,27 +217,26 @@ export const TokenRowWallets = component$<TokenRowWalletsProps>(
         .value;
       latestTokenPrice.value = (await data.next()).value["price"];
 
-      let previousTime = "1970-01-01T00:00:00Z";
-      let recentTime;
-      for await (const value of data) {
-        if (value.action === "CREATE") {
-          if (value.type === "BALANCE") {
-            recentTime = value.result["timestamp"];
-            if (
-              new Date(recentTime).getTime() >= new Date(previousTime).getTime()
-            ) {
+      let previousTime = new Date("1970-01-01T00:00:00Z").getTime();
+
+      for await (const { action, type, result } of data) {
+        const { timestamp, walletValue, price } = result;
+        if (action === "CREATE") {
+          if (type === "BALANCE") {
+            let recentTime = timestamp;
+            if (new Date(recentTime).getTime() >= previousTime) {
               currentBalanceOfToken.value = convertWeiToQuantity(
-                value.result["walletValue"],
+                walletValue,
                 parseInt(decimals),
               );
               previousTime = recentTime;
             }
           } else {
-            latestTokenPrice.value = value.result["price"];
+            latestTokenPrice.value = price;
           }
-        } else if (value.action === "UPDATE") {
-          if (value.type === "PRICE") {
-            latestTokenPrice.value = value.result["price"];
+        } else if (action === "UPDATE") {
+          if (type === "PRICE") {
+            latestTokenPrice.value = price;
           }
         }
       }

--- a/src/components/Tokens/TokenRowWallets.tsx
+++ b/src/components/Tokens/TokenRowWallets.tsx
@@ -217,9 +217,7 @@ export const TokenRowWallets = component$<TokenRowWalletsProps>(
         .value;
       latestTokenPrice.value = (await data.next()).value["price"];
 
-      let timeOfPreviousBalanceChange = new Date(
-        "1970-01-01T00:00:00Z",
-      ).getTime();
+      let timeOfPreviousBalanceChange = 0;
 
       for await (const { action, type, result } of data) {
         const { timestamp, walletValue, price } = result;

--- a/src/entry.express.tsx
+++ b/src/entry.express.tsx
@@ -23,7 +23,7 @@ import fs from "fs";
 import http2Express from "http2-express-bridge";
 
 declare global {
-  interface QwikCityPlatform extends PlatformNode {}
+  interface QwikCityPlatform extends PlatformNode { }
 }
 
 // Directories where the static assets are located
@@ -67,8 +67,8 @@ app.use(router);
 app.use(notFound);
 
 const httpsOptions = {
-  key: fs.readFileSync("./ssl/localhost-key.pem"),
-  cert: fs.readFileSync("./ssl/localhost.pem"),
+  key: fs.readFileSync("./ssl/127.0.0.1-key.pem"),
+  cert: fs.readFileSync("./ssl/127.0.0.1.pem"),
   allowHTTP1: true,
 };
 

--- a/src/entry.express.tsx
+++ b/src/entry.express.tsx
@@ -23,7 +23,7 @@ import fs from "fs";
 import http2Express from "http2-express-bridge";
 
 declare global {
-  interface QwikCityPlatform extends PlatformNode { }
+  interface QwikCityPlatform extends PlatformNode {}
 }
 
 // Directories where the static assets are located

--- a/src/routes/app/automation/_components/AddAutomationModal.tsx
+++ b/src/routes/app/automation/_components/AddAutomationModal.tsx
@@ -93,7 +93,7 @@ export const AddAutomationModal = component$<AddAutomationModalProps>(
           isVisible: true,
         });
       } catch (err) {
-        console.log(err);
+        console.error(err);
         formMessageProvider.messages.push({
           id: formMessageProvider.messages.length,
           variant: "error",

--- a/src/routes/app/automation/_components/AutomationsMenu.tsx
+++ b/src/routes/app/automation/_components/AutomationsMenu.tsx
@@ -5,23 +5,23 @@ import {
   useSignal,
   useVisibleTask$,
 } from "@builder.io/qwik";
-import Button from "~/components/Atoms/Buttons/Button";
-import Checkbox from "~/components/Atoms/Checkbox/Checkbox";
-import { connectToDB } from "~/database/db";
 import { server$ } from "@builder.io/qwik-city";
-import { AddAutomationModal } from "./AddAutomationModal";
-import { AutomationPageContext } from "../AutomationPageContext";
 import {
-  type Config,
   getAccount,
   simulateContract,
   writeContract,
+  type Config,
 } from "@wagmi/core";
 import { emethContractAbi } from "~/abi/emethContractAbi";
-import { WagmiConfigContext } from "~/components/WalletConnect/context";
+import Button from "~/components/Atoms/Buttons/Button";
+import Checkbox from "~/components/Atoms/Checkbox/Checkbox";
 import Input from "~/components/Atoms/Input/Input";
-import ParagraphAnnotation from "~/components/Molecules/ParagraphAnnotation/ParagraphAnnotation";
 import BoxHeader from "~/components/Molecules/BoxHeader/BoxHeader";
+import ParagraphAnnotation from "~/components/Molecules/ParagraphAnnotation/ParagraphAnnotation";
+import { WagmiConfigContext } from "~/components/WalletConnect/context";
+import { connectToDB } from "~/database/db";
+import { AutomationPageContext } from "../AutomationPageContext";
+import { AddAutomationModal } from "./AddAutomationModal";
 
 const updateIsActiveStatus = server$(async function (actionId, isActive) {
   const db = await connectToDB(this.env);
@@ -31,7 +31,7 @@ const updateIsActiveStatus = server$(async function (actionId, isActive) {
       { actionId: actionId, isActive: isActive },
     );
   } catch (err) {
-    console.log(err);
+    console.error(err);
   }
 });
 
@@ -84,15 +84,11 @@ export const AutomationsMenu = component$<AutomationsMenuProps>(() => {
           },
         );
 
-        const transactionHash = await writeContract(
-          wagmiConfig.config.value as Config,
-          request,
-        );
-        console.log(transactionHash);
+        await writeContract(wagmiConfig.config.value as Config, request);
       }
       await updateIsActiveStatus(actionId, isActive);
     } catch (err) {
-      console.log(err);
+      console.error(err);
     }
   });
 

--- a/src/routes/app/automation/_components/CentralView.tsx
+++ b/src/routes/app/automation/_components/CentralView.tsx
@@ -27,7 +27,7 @@ const deleteActionFromDb = server$(async function (actionId, user) {
       },
     );
   } catch (err) {
-    console.log(err);
+    console.error(err);
   }
 });
 
@@ -51,7 +51,7 @@ export const CentralView = component$<CentralViewProps>(() => {
         isVisible: true,
       });
     } catch (err) {
-      console.log(err);
+      console.error(err);
       formMessageProvider.messages.push({
         id: formMessageProvider.messages.length,
         variant: "error",

--- a/src/routes/app/automation/_components/TriggerDrawer.tsx
+++ b/src/routes/app/automation/_components/TriggerDrawer.tsx
@@ -70,7 +70,7 @@ const updateAutomationAction = server$(
         },
       );
     } catch (err) {
-      console.log(err);
+      console.error(err);
     }
   },
 );
@@ -156,11 +156,7 @@ export const TriggerDrawer = component$<TriggerDrawerProps>(() => {
         },
       );
 
-      const transactionHash = await writeContract(
-        wagmiConfig.config.value as Config,
-        request,
-      );
-      console.log(transactionHash);
+      await writeContract(wagmiConfig.config.value as Config, request);
       const user = localStorage.getItem("emmethUserWalletAddress");
       await updateAutomationAction(
         isActive,
@@ -183,7 +179,7 @@ export const TriggerDrawer = component$<TriggerDrawerProps>(() => {
         isVisible: true,
       });
     } catch (err) {
-      console.log(err);
+      console.error(err);
       formMessageProvider.messages.push({
         id: formMessageProvider.messages.length,
         variant: "error",
@@ -371,7 +367,7 @@ export const TriggerDrawer = component$<TriggerDrawerProps>(() => {
                   await handleAddAutomation();
                   automationPageContext.isDraverOpen.value = false;
                 } catch (err) {
-                  console.log(err);
+                  console.error(err);
                 }
               })}
             />

--- a/src/routes/app/portfolio/_components/Swap/Swap.tsx
+++ b/src/routes/app/portfolio/_components/Swap/Swap.tsx
@@ -200,7 +200,7 @@ export const SwapModal = component$<SwapModalProps>(
       });
 
       try {
-        const swap = await swapTokensForTokens(
+        await swapTokensForTokens(
           swapValues.chosenToken.address.value as `0x${string}`,
           swapValues.tokenToSwapOn.address as `0x${string}`,
           swapValues.chosenToken.value,
@@ -208,7 +208,6 @@ export const SwapModal = component$<SwapModalProps>(
           swapValues.accountToSendTokens as `0x${string}`,
           wagmiConfig,
         );
-        console.log(swap);
         formMessageProvider.messages.push({
           id: formMessageProvider.messages.length,
           variant: "success",
@@ -216,7 +215,7 @@ export const SwapModal = component$<SwapModalProps>(
           isVisible: true,
         });
       } catch (err) {
-        console.log("swapping error: ", err);
+        console.error("swapping error: ", err);
         formMessageProvider.messages.push({
           id: formMessageProvider.messages.length,
           variant: "error",

--- a/src/routes/app/portfolio/index.tsx
+++ b/src/routes/app/portfolio/index.tsx
@@ -164,7 +164,6 @@ export default component$(() => {
 
   // eslint-disable-next-line qwik/no-use-visible-task
   useVisibleTask$(async () => {
-    console.log("portfolio config: ", wagmiConfig.config.value);
     availableStructures.value = await getAvailableStructures();
     observedWalletsWithBalance.value = await getObservedWalletBalances();
   });
@@ -242,7 +241,6 @@ export default component$(() => {
           wagmiConfig.config.value,
           request,
         );
-        console.log(transactionHash);
         await waitForTransactionReceipt(wagmiConfig.config.value, {
           hash: transactionHash,
         });
@@ -380,7 +378,6 @@ export default component$(() => {
               </div>
               {availableStructures.value.structures.map(
                 (createdStructures: any) => {
-                  console.log("created structures", createdStructures);
                   return (
                     <Group
                       key={createdStructures.structure.name}


### PR DESCRIPTION
when we listen for records from live query they come in descending order. so when we quickly click on wallet the balance is set for the last thing that is created in db which is the oldest balance (because we listen for create action). check i added prevents balance being overwritten by some older historical balance.